### PR TITLE
feat: add Go bootstrap example (minimal HTTP + tests)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,16 @@
+name: Go CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Run tests
+        run: go test ./...
+      - name: Vet
+        run: go vet ./...

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+	port := 8080
+	fmt.Printf("Listening on :%d\n", port)
+	http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/networkniceit/nnit-ai-freelance-backend-example
+
+go 1.20

--- a/server/health_test.go
+++ b/server/health_test.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
Adds a minimal Go example with a  handler, a  based test, and a GitHub Actions workflow that runs FAIL	. [setup failed] and . This is a small bootstrap to demonstrate the Go conventions and pipeline.